### PR TITLE
change the paperround S3 access to the agreed folder name

### DIFF
--- a/cdk/lib/__snapshots__/national-delivery-fulfilment.test.ts.snap
+++ b/cdk/lib/__snapshots__/national-delivery-fulfilment.test.ts.snap
@@ -58,7 +58,7 @@ exports[`The NationalDeliveryFulfilment stack matches the snapshot 1`] = `
             {
               "Action": "s3:PutObject",
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::gu-national-delivery-fulfilment-code/processed-failed-delivery-files/*",
+              "Resource": "arn:aws:s3:::gu-national-delivery-fulfilment-code/failed-deliveries/uploads/*",
             },
           ],
           "Version": "2012-10-17",
@@ -467,7 +467,7 @@ exports[`The NationalDeliveryFulfilment stack matches the snapshot 2`] = `
             {
               "Action": "s3:PutObject",
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::gu-national-delivery-fulfilment-prod/processed-failed-delivery-files/*",
+              "Resource": "arn:aws:s3:::gu-national-delivery-fulfilment-prod/failed-deliveries/uploads/*",
             },
           ],
           "Version": "2012-10-17",

--- a/cdk/lib/national-delivery-fulfilment.ts
+++ b/cdk/lib/national-delivery-fulfilment.ts
@@ -102,7 +102,7 @@ export class NationalDeliveryFulfilment extends GuStack {
                         "s3:PutObject"
                     ],
                     resources: [
-                        `arn:aws:s3:::${bucketName}/processed-failed-delivery-files/*`
+                        `arn:aws:s3:::${bucketName}/failed-deliveries/uploads/*`
                     ],
                 }
             )


### PR DESCRIPTION
Updating the write access to the agreed folder name

/fulfilment/YYYY/YYYY-MM/
fulfilment files will be picked up by paperround from this location
paperround access: Read

/failed-deliveries/uploads
paperround should put failed delivery files here
paperround access: Write

/failed-deliveries/processed-files
processed failed delivery files + processing summary docs go here
paperround access: None