### PR TITLE
filter away subscriptions with empty delivery reference

### DIFF
--- a/src/libs/transforms.ts
+++ b/src/libs/transforms.ts
@@ -146,3 +146,16 @@ export function excludeHolidaySubscriptions(subcriptions: ZuoraSubscription[], n
     return !names.includes(sub.subscription_name);
   });
 }
+
+function subscriptionIsCorrect(subscription: ZuoraSubscription): boolean {
+  if(subscription.subscription_delivery_agent == ""){
+    return false;
+  }
+  return true;
+}
+
+export function retainCorrectSubscriptions(subscriptions: ZuoraSubscription[]): ZuoraSubscription[] {
+  return subscriptions.filter(sub => {
+    return subscriptionIsCorrect(sub);
+  });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
          
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
-import { FileRecord, subscriptionsToFileRecords, fileRecordsToCSVFile, subscriptionsDataFileToSubscriptions, excludeHolidaySubscriptions, holidayNamesDataFileToNames } from './libs/transforms'
+import { FileRecord, subscriptionsToFileRecords, fileRecordsToCSVFile, subscriptionsDataFileToSubscriptions, excludeHolidaySubscriptions, holidayNamesDataFileToNames, retainCorrectSubscriptions } from './libs/transforms'
 import { commitFileToS3_v3 } from './libs/s3'
 import { Stage } from './utils/config'
 import { cycleDataFilesFromZuora, fetchZuoraBearerToken2 } from './libs/zuora'
@@ -21,10 +21,11 @@ export const main = async () => {
       const date = cursor.format("YYYY-MM-DD");
       console.log(`i: ${i}; date: ${date}`);
       const zuoraDataFiles = await cycleDataFilesFromZuora(Stage, zuoraBearerToken, date);
-      const subscriptions1 = subscriptionsDataFileToSubscriptions(zuoraDataFiles.subscriptionsFile);
+      const subscriptions1a = subscriptionsDataFileToSubscriptions(zuoraDataFiles.subscriptionsFile);
+      const subscriptions1b = retainCorrectSubscriptions(subscriptions1a)
       const holidaySubscriptionNames = holidayNamesDataFileToNames(zuoraDataFiles.holidayNamesFile);
       console.log(holidaySubscriptionNames);
-      const subscriptions2 = excludeHolidaySubscriptions(subscriptions1, holidaySubscriptionNames);
+      const subscriptions2 = excludeHolidaySubscriptions(subscriptions1b, holidaySubscriptionNames);
       const sentDate = now.format("DD/MM/YYYY");
       const deliveryDate = cursor.format("DD/MM/YYYY");
       const fileRecords = subscriptionsToFileRecords(subscriptions2, sentDate, deliveryDate);


### PR DESCRIPTION
During testing there were test subscriptions with empty attribute `subscription_delivery_agent`, which resulted in file records with empty `Retailer Reference`. Here we filter them out. 

This change cleans the test files, but can also actually go to prod. Any problem with a null delivery agent will always result in a non delivery which will then will need to be solved in the source system.