### PR TITLE
give supplier read access to the failed delivery files also

### DIFF
--- a/cdk/lib/__snapshots__/national-delivery-fulfilment.test.ts.snap
+++ b/cdk/lib/__snapshots__/national-delivery-fulfilment.test.ts.snap
@@ -72,7 +72,10 @@ exports[`The NationalDeliveryFulfilment stack matches the snapshot 1`] = `
         "PolicyDocument": {
           "Statement": [
             {
-              "Action": "s3:PutObject",
+              "Action": [
+                "s3:GetObject",
+                "s3:PutObject",
+              ],
               "Effect": "Allow",
               "Resource": "arn:aws:s3:::gu-national-delivery-fulfilment-code/failed-deliveries/uploads/*",
             },
@@ -497,7 +500,10 @@ exports[`The NationalDeliveryFulfilment stack matches the snapshot 2`] = `
         "PolicyDocument": {
           "Statement": [
             {
-              "Action": "s3:PutObject",
+              "Action": [
+                "s3:GetObject",
+                "s3:PutObject",
+              ],
               "Effect": "Allow",
               "Resource": "arn:aws:s3:::gu-national-delivery-fulfilment-prod/failed-deliveries/uploads/*",
             },

--- a/cdk/lib/national-delivery-fulfilment.ts
+++ b/cdk/lib/national-delivery-fulfilment.ts
@@ -112,6 +112,7 @@ export class NationalDeliveryFulfilment extends GuStack {
                 "AllowFulfilmentBucketPutFailedDeliveryPolicy",
                 {
                     actions: [
+                        "s3:GetObject",
                         "s3:PutObject"
                     ],
                     resources: [


### PR DESCRIPTION
They want to see in the folder as well as write to it.