### PR TITLE
Deal with slow PROD runs by spreading file generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,17 @@ The generation of one file is an atomic operation in the sense that it's perform
 
 The lambda is set up to run each hour and it generates the next file every hour. It generates all 14 files during the first 14 hours of the day. (And, currently, there actually is two generations of files 1 to 10. For instance the first file, the file for "tomorrow", is generated at 00:30 and at 14:30)
 
-It is also possible to generate a particular file in the aws console. In this case, just provide the file index as input to the lambda. A single number, for instance 10, given as imput to the lambda is going to ensure that the file with index 10 (corresponding to 10 days in the future) is going to be generated during one run of the lambda. Note that is it not currently offered to generate more than one file per run of the lambda (actually it's perfectly possible but we simply not provide that ability, mostly because it would only really be relevant in CODE).
+It is also possible to generate a particular file in the aws console (see next section). In this case, just provide the file index as input to the lambda. A single number, for instance 10, given as imput to the lambda is going to ensure that the file with index 10 (corresponding to 10 days in the future) is going to be generated during one run of the lambda. Note that is it not currently offered to generate more than one file per run of the lambda (actually it's perfectly possible but we simply not provide that ability, mostly because it would only really be relevant in CODE).
+
+### Generate a specific file from the AWS console.
+
+To generate a specific file from the AWS console, you need to specify the day you want to run and for this you will use a day index. It's simply a integer number of days from today (1 for tomorrow, etc). To do so use an event as follow (for instance for index 3)
+
+```
+{
+  "dayIndex": 3,
+}
+```
 
 ### Local developement
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,54 @@
 
-## National Deliveries Fulfilment Lambda
+### National Delivery Fulfilment Lambda
 
-### Bucket Names
+The national delivery fulfilment lambda generates the files used by Paperround for delivery.
+
+The files are generated in the membership account, and the two S3 buckets:
 
 ```
 - national-delivery-fulfilment-prod
 - national-delivery-fulfilment-code
 ```
 
-### Building Cloudformation
+Each file is named after the day it was generated for, using the naming convention YYYY-MM-DD.csv, for instance 2023-11-01.csv for the file generated for 1 November 2023. The files are located in a hierarchical structure in the bucket following the convention
 
-inside the `cdk` folder
+```
+[bucket]/fulfilment/YYYY/YYYY-MM/YYYY-MM-DD.csv
+```
+
+For instance the file 2023-11-01.csv, will be located at
+
+```
+[bucket]/fulfilment/2023/2023-11/2023-11-01.csv
+```
+
+We generates 14 files starting from the day after. For instance on the 2nd of November 2023, we generate all files for 2023-11-03 up to 2023-11-16. The program internally refers to those dates by their index. Index 1 for tomorrow (aka: today + 1 day), etc., up to index 14.
+
+### Generation strategy
+
+The generation of one file is an atomic operation in the sense that it's performed by one single asynchronous function (see code for detail). We are going to retain that design principle and we can keep it as long at it remains true that a single file takes less than 15 mins to be generated. If one day that premisse cease to be true, then a small redesign will be required. At the time these line are written (Oct 2023), the generation takes few seconds in CODE and about 5 mins (300 seconds) in PROD.
+
+The lambda is set up to run each hour and it generates the next file every hour. It generates all 14 files during the first 14 hours of the day. (And, currently, there actually is two generations of files 1 to 10. For instance the first file, the file for "tomorrow", is generated at 00:30 and at 14:30)
+
+It is also possible to generate a particular file in the aws console. In this case, just provide the file index as input to the lambda. A single number, for instance 10, given as imput to the lambda is going to ensure that the file with index 10 (corresponding to 10 days in the future) is going to be generated during one run of the lambda. Note that is it not currently offered to generate more than one file per run of the lambda (actually it's perfectly possible but we simply not provide that ability, mostly because it would only really be relevant in CODE).
+
+### Local developement
 
 ```
 $ yarn install --frozen-lockfile
-$ npm test -- -u # accepting a new cdk snapshot
+```
+
+### Building Cloudformation
+
+Upon any modification of the cloud formation, the smapshot needs to be updated in the source code. For this, move to the `cdk` folder and run.
+
+```
+$ npm test -- -u
 ```
 
 ### Playground
+
+Playground is a directory that was used during initial development, it's going to be removed shortly after we go live.
 
 - `$ npx ts-node src/playground/s3.ts`
 - `$ npx ts-node src/playground/zuora.ts`
@@ -25,5 +56,7 @@ $ npm test -- -u # accepting a new cdk snapshot
 ### Running on local
 
 - running main.ts
-  
-  1. `$ npx ts-node src/main.ts`
+
+```
+$ npx ts-node src/main.ts
+```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,17 @@
 
 The national delivery fulfilment lambda generates the files used by Paperround for delivery.
 
-The files are generated in the membership account, and the two S3 buckets:
+For deployment see `MemSub::Fulfilment::NationalDelivery` in Riff-Raff.
+
+The files are generated in the membership account, by the two lambda functions
+
+```
+- membership-national-delivery-fulfilment-CODE
+- membership-national-delivery-fulfilment-PROD
+```
+
+
+and put in the two S3 buckets:
 
 ```
 - national-delivery-fulfilment-prod

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To generate a specific file from the AWS console, you need to specify the day yo
 
 ```
 {
-  "dayIndex": 3,
+  "dayIndex": 3
 }
 ```
 

--- a/cdk/lib/__snapshots__/national-delivery-fulfilment.test.ts.snap
+++ b/cdk/lib/__snapshots__/national-delivery-fulfilment.test.ts.snap
@@ -387,9 +387,9 @@ exports[`The NationalDeliveryFulfilment stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
-    "nationaldeliveryfulfilmentlambdanationaldeliveryfulfilmentlambdacron30609BEBC0D2": {
+    "nationaldeliveryfulfilmentlambdanationaldeliveryfulfilmentlambdacron3009BF94F13": {
       "Properties": {
-        "ScheduleExpression": "cron(30 6 * * ? *)",
+        "ScheduleExpression": "cron(30 * * * ? *)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -405,7 +405,7 @@ exports[`The NationalDeliveryFulfilment stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Events::Rule",
     },
-    "nationaldeliveryfulfilmentlambdanationaldeliveryfulfilmentlambdacron3060AllowEventRuleNationalDeliveryFulfilmentCODEnationaldeliveryfulfilmentlambda83C15CF276003C02": {
+    "nationaldeliveryfulfilmentlambdanationaldeliveryfulfilmentlambdacron300AllowEventRuleNationalDeliveryFulfilmentCODEnationaldeliveryfulfilmentlambda83C15CF27F01F0A8": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
@@ -417,7 +417,7 @@ exports[`The NationalDeliveryFulfilment stack matches the snapshot 1`] = `
         "Principal": "events.amazonaws.com",
         "SourceArn": {
           "Fn::GetAtt": [
-            "nationaldeliveryfulfilmentlambdanationaldeliveryfulfilmentlambdacron30609BEBC0D2",
+            "nationaldeliveryfulfilmentlambdanationaldeliveryfulfilmentlambdacron3009BF94F13",
             "Arn",
           ],
         },
@@ -815,9 +815,9 @@ exports[`The NationalDeliveryFulfilment stack matches the snapshot 2`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
-    "nationaldeliveryfulfilmentlambdanationaldeliveryfulfilmentlambdacron30609BEBC0D2": {
+    "nationaldeliveryfulfilmentlambdanationaldeliveryfulfilmentlambdacron3009BF94F13": {
       "Properties": {
-        "ScheduleExpression": "cron(30 6 * * ? *)",
+        "ScheduleExpression": "cron(30 * * * ? *)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -833,7 +833,7 @@ exports[`The NationalDeliveryFulfilment stack matches the snapshot 2`] = `
       },
       "Type": "AWS::Events::Rule",
     },
-    "nationaldeliveryfulfilmentlambdanationaldeliveryfulfilmentlambdacron3060AllowEventRuleNationalDeliveryFulfilmentPRODnationaldeliveryfulfilmentlambda8B0CC485D6B0DB02": {
+    "nationaldeliveryfulfilmentlambdanationaldeliveryfulfilmentlambdacron300AllowEventRuleNationalDeliveryFulfilmentPRODnationaldeliveryfulfilmentlambda8B0CC48557D9E833": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
@@ -845,7 +845,7 @@ exports[`The NationalDeliveryFulfilment stack matches the snapshot 2`] = `
         "Principal": "events.amazonaws.com",
         "SourceArn": {
           "Fn::GetAtt": [
-            "nationaldeliveryfulfilmentlambdanationaldeliveryfulfilmentlambdacron30609BEBC0D2",
+            "nationaldeliveryfulfilmentlambdanationaldeliveryfulfilmentlambdacron3009BF94F13",
             "Arn",
           ],
         },

--- a/cdk/lib/national-delivery-fulfilment.ts
+++ b/cdk/lib/national-delivery-fulfilment.ts
@@ -30,7 +30,7 @@ export class NationalDeliveryFulfilment extends GuStack {
                 rules: [{
                     schedule: Schedule.cron({
                         day: '*',
-                        hour: '6',
+                        hour: '*',
                         minute: '30',
                     }),
                 }],

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,7 @@
-import { APIGatewayProxyCallback, Context } from "aws-lambda";
+
+import { Handler } from 'aws-lambda';
 import { main } from "./main";
 
-export async function handler(
-  event: APIGatewayEvent,
-  context: Context,
-  callback: APIGatewayProxyCallback
-) {
-  await main();
-}
-
-export interface APIGatewayEvent {
-  headers: Record<string, string | undefined>;
-  path: string;
-  body: string;
+export const handler: Handler = async (event, context) => {
+  await main(event);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export const handler: Handler = async (event) => {
 
     ... or a user defined event, which is expected to be like this: 
     {
-        "dayIndex": 3,
+        "dayIndex": 3
     }
     // See description in the readme for details. 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,32 @@
 import { Handler } from 'aws-lambda';
 import { main } from "./main";
 
-export const handler: Handler = async (event, context) => {
-  await main(event);
+export const handler: Handler = async (event) => {
+
+  /*
+
+  We receive two kinds of events, either the event sent by AWS during the scheduled run, which looks like this:
+    {
+        "version": "0",
+        "id": "f53402cc-287b-663b-f734-31ea35f66df9",
+        "detail-type": "Scheduled Event",
+        "source": "aws.events",
+        "account": "[removed]",
+        "time": "2023-10-29T20:30:00Z",
+        "region": "eu-west-1",
+        "resources": [
+            "arn:aws:events:[removed]"
+        ],
+        "detail": {}
+    }
+
+    ... or a user defined event, which is expected to be like this: 
+    {
+        "dayIndex": 3,
+    }
+    // See description in the readme for details. 
+
+  */
+
+  await main(event["dayIndex"]);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,39 +29,6 @@ export const main = async (dayIndex?: number) => {
   console.log("main function completed");
 };
 
-async function generateFilesForAllDaysSequential(zuoraBearerToken: string) {
-  // Date: 29th October 2023
-  // This function is currently not used but kept for a bit for illustration purposes.
-
-  // It generates all 14 files sequentially.
-
-  // This actually was the original implementation that was abandonned when it was discovered that 
-  // The production run is so slow that the lambda expires (is killed after 15 minutes: the max time a 
-  // lambda can run in AWS), and that, before the 14th file is generated.
-
-  const indices = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14];
-  for (const i of indices) {
-    await generateFileForDay(zuoraBearerToken, i);
-  }
-}
-
-async function generateFilesForAllDaysParallel(zuoraBearerToken: string) {
-  // Date: 29th October 2023
-  // This function is currently not used but kept for a bit for illustration purposes.
-
-  // It generates all 14 files in parallel. 
-
-  // This version was introduced to solve the problem posed by sequential run and AWS killing the lambda after 
-  // 15 mins, but it is not recommanded for regular use because apparently Zuora doesn't always behave well when running
-  // jobs in parallel.
-
-  const indices = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14];
-  const promises = indices.map(async (i) => {
-    return generateFileForDay(zuoraBearerToken, i);
-  });
-  await Promise.all(promises);
-}
-
 async function generateOneFileUsingCurrentTimeToDeriveDayIndex(zuoraBearerToken: string) {
 
   // Date: 29th October 2023

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,15 +9,22 @@ import { Credentials } from 'aws-sdk/lib/core';
 import { getSsmValue } from "./utils/ssm";
 import { sleep } from "./utils/sleep";
 
-export const main = async (event) => {
-  console.log("main function start");
-  console.log(`event: ${JSON.stringify(event)}`);
+export const main = async (dayIndex?: number) => {
+  console.log(`main function start with dayIndex: ${dayIndex}`);
   
+  // The dayIndex is either not defined if this was a scheduled run, 
+  // or the dayIndex requested by the user from a manual run in the aws console. 
+
   const zuoraBearerToken = await fetchZuoraBearerToken2(Stage);
-  if (zuoraBearerToken) {
-    await generateOneFileUsingCurrentTimeToDeriveDayIndex(zuoraBearerToken);
+  if (!zuoraBearerToken) {
+    const message = "Could not extract a bearer token from zuora";
+    console.log(message);
+    throw message;
+  }
+  if (dayIndex) {
+    await generateFileForDay(zuoraBearerToken, dayIndex);
   } else {
-    console.log("Could not extract a bearer token from zuora")
+    await generateOneFileUsingCurrentTimeToDeriveDayIndex(zuoraBearerToken);
   }
   console.log("main function completed");
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,37 +9,101 @@ import { Credentials } from 'aws-sdk/lib/core';
 import { getSsmValue } from "./utils/ssm";
 import { sleep } from "./utils/sleep";
 
-export const main = async () => {
-  console.log("main function: start");
-  const now = moment();
+export const main = async (event) => {
+  console.log("main function start");
+  console.log(`event: ${JSON.stringify(event)}`);
+  
   const zuoraBearerToken = await fetchZuoraBearerToken2(Stage);
   if (zuoraBearerToken) {
-    await generateFilesForAllDays(zuoraBearerToken, now);
+    await generateOneFileUsingCurrentTimeToDeriveDayIndex(zuoraBearerToken);
   } else {
     console.log("Could not extract a bearer token from zuora")
   }
-  console.log("main function: completed");
+  console.log("main function completed");
 };
 
-async function generateFilesForAllDays(zuoraBearerToken: string, now: moment.Moment) {
-  const today = now.format("YYYY-MM-DD");
-  const indices = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]; // There probably a sexier way to do this
+async function generateFilesForAllDaysSequential(zuoraBearerToken: string) {
+  // Date: 29th October 2023
+  // This function is currently not used but kept for a bit for illustration purposes.
+
+  // It generates all 14 files sequentially.
+
+  // This actually was the original implementation that was abandonned when it was discovered that 
+  // The production run is so slow that the lambda expires (is killed after 15 minutes: the max time a 
+  // lambda can run in AWS), and that, before the 14th file is generated.
+
+  const indices = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14];
+  for (const i of indices) {
+    await generateFileForDay(zuoraBearerToken, i);
+  }
+}
+
+async function generateFilesForAllDaysParallel(zuoraBearerToken: string) {
+  // Date: 29th October 2023
+  // This function is currently not used but kept for a bit for illustration purposes.
+
+  // It generates all 14 files in parallel. 
+
+  // This version was introduced to solve the problem posed by sequential run and AWS killing the lambda after 
+  // 15 mins, but it is not recommanded for regular use because apparently Zuora doesn't always behave well when running
+  // jobs in parallel.
+
+  const indices = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14];
   const promises = indices.map(async (i) => {
-    const cursor = moment().add(i, "days");
-    return generateFileForDay(zuoraBearerToken, now, cursor);
+    return generateFileForDay(zuoraBearerToken, i);
   });
   await Promise.all(promises);
 }
 
-async function generateFileForDay(zuoraBearerToken: string, now: moment.Moment, cursor: moment.Moment) {
+async function generateOneFileUsingCurrentTimeToDeriveDayIndex(zuoraBearerToken: string) {
+
+  // Date: 29th October 2023
+
+  // Here is the current, most recent scheme for file generation. Since we cannot generate all 14 files
+  // sequentially in production, and since running them in parallel is not advised (source: John), we are 
+  // simply going to spread the generation over a period of time. In this current version we simply generate the 
+  // files over 14 hours
+
+  // dayIndex is derived from the current hour of the day
+  // Time 00:MM -> dayIndex = 1
+  // Time 01:MM -> dayIndex = 2
+  // ...
+  // Time 13:MM -> dayIndex = 14
+  // Time 14:MM -> dayIndex = 1
+  // etc...
+
+  const dayIndex = 1 + ((new Date()).getUTCHours() % 14);
+
+  await generateFileForDay(zuoraBearerToken, dayIndex);
+}
+
+async function generateFileForDay(zuoraBearerToken: string, dayIndex: number) {
+
+  // This function generates one file. The date of the file that is being generated is derived from the dayIndex
+  // dayIndex = 1 -> tomorrow
+  // dayIndex = 2 -> two days from now, etc...
+
+  // The file generation is a linear sequence of steps that essentially perform 3 main operations:
+
+  // 1. Retrieve subscription and holiday data from Zuora
+  // 2. combine the two datasets using pure functions
+  // 3. Write the resulting file into S3
+
+  console.log(`Generating dayIndex: ${dayIndex}`);
+
+  const now = moment();
+  const cursor = moment().add(dayIndex, "days");
+
   const today = now.format("YYYY-MM-DD");
-  const date = cursor.format("YYYY-MM-DD");
-  console.log(`date: ${date}`);
-  const zuoraDataFiles = await cycleDataFilesFromZuora(Stage, zuoraBearerToken, date, today);
+  const targetDate = cursor.format("YYYY-MM-DD");
+
+  console.log(`today: ${today}`);
+  console.log(`targetDate: ${targetDate}`);
+
+  const zuoraDataFiles = await cycleDataFilesFromZuora(Stage, zuoraBearerToken, targetDate, today);
   const currentSubs = subscriptionsDataFileToSubscriptions(zuoraDataFiles.subscriptionsFile);
   const subsWithoutInvalid = retainCorrectSubscriptions(currentSubs)
   const holidaySubscriptionNames = holidayNamesDataFileToNames(zuoraDataFiles.holidayNamesFile);
-  console.log(holidaySubscriptionNames);
   const subsWithoutHolidayStops = excludeHolidaySubscriptions(subsWithoutInvalid, holidaySubscriptionNames);
   const sentDate = now.format("DD/MM/YYYY");
   const deliveryDate = cursor.format("DD/MM/YYYY");


### PR DESCRIPTION
Upon discovering that the Zuora production version runs much slower than the CODE environment (pushing the generation of 14 files above the 15 mins limit of AWS lambda maximum runtime), the next natural adaptation was to run the files in parallel (as done here: https://github.com/guardian/national-delivery-fulfilment/pull/16), but @johnduffell advised against it. 

Here we come back to linear generation but simply spread the 14 files generation over 14 runs of the lambda, instead of one run. 

This obviously raises the issue of keeping memory of which files has been generated. In this version of the program the index of the file to generate (which decide the date) is simply derived from the current time. Accordingly we moved the lambda run from once per day to once per hour (half past the hour).  

We also provide the mechanism to specify a given date, for manual AWS console runs.

Note: the algebra used in this PR is only one of possible ways to specify the target date (and was mostly selected for educational purposes), there are other ways :)  

ps:

The logic of this PR is very simple (and yet powerful), and remember that a lot of things (for instance running the lambda every hour) are only true because of the existing specifications. 

Interesting questions are: "But what happens if one day the Guardian and PPR decide to generate 30 days in advance? This would not work because there are only 24 hours in a day!", or "What if we want to generate the files in a shorter time, for instance the first 7 hours after midnight?" 

The solutions to those problems is left as exercise for the reader 😉