### PR TITLE
repair tests invocation

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
   "scripts": {
     "build": "yarn esbuild --bundle --platform=node --target=node18 --outfile=dist/index.js src/index.ts",
     "package": "cd dist; zip -qr ../cdk/national-delivery-fulfilment/national-delivery-fulfilment.zip ./*",
-    "test": "cd test && ts-jest"
+    "test": "cd test && jest"
   }
 }


### PR DESCRIPTION
The tests are not running in GHA because of a typo in the invocation. Interestingly that didn't cause the workflow itself to fail 🤔 

The are running (and passing) now: https://github.com/guardian/national-delivery-fulfilment/actions/runs/6906383737/job/18791292803

```
Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        5.77 s
Ran all test suites.
Done in 6.35s.
```