### PR TITLE
update generation schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ We generates 14 files starting from the day after. For instance on the 2nd of No
 
 The generation of one file is an atomic operation in the sense that it's performed by one single asynchronous function (see code for detail). We are going to retain that design principle and we will keep it as long at it remains true that a single file takes less than 15 mins to be generated. If one day that premisse ceases to be true, then a small redesign of this lambda will be required. At the time these lines are written (Oct 2023), the generation takes few seconds in CODE and a couple of minutes (sometimes up to 5 mins, and in extremelly rare cases up to 10 mins) in PROD.
 
-The lambda is set up to run each hour and generates the next file every hour. It generates all 14 files during the first 14 hours of the day. And then regenerate some of the files, during the remaining hours.
+The lambda generates all files from [today]+2 to [today]+14, and ensures that [today]+2. Moreover we do not generate any file at hour 0 (meaning between midnight and 1am) and we do not generate file index 2, eg: [today]+2, after 10am.
 
-It is also possible to manually generate a particular file (or a small number of files) in the aws console (see next section).
+It is possible to manually generate a particular file (or a small number of files) in the aws console (see next section).
 
 ### Generate a specific file from the AWS console.
 
@@ -64,9 +64,19 @@ Note that if you provide too a many indices, you may cause the lambda to exeed t
 
 ### Local developement
 
+Upon closing the repository, run:
+
 ```
 $ yarn install --frozen-lockfile
 ```
+
+To comply with the linting rules, run:
+
+```
+$ yarn lint --fix
+```
+
+before making your commits.
 
 ### Building Cloudformation
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ We generates 14 files starting from the day after. For instance on the 2nd of No
 
 The generation of one file is an atomic operation in the sense that it's performed by one single asynchronous function (see code for detail). We are going to retain that design principle and we will keep it as long at it remains true that a single file takes less than 15 mins to be generated. If one day that premisse ceases to be true, then a small redesign of this lambda will be required. At the time these lines are written (Oct 2023), the generation takes few seconds in CODE and a couple of minutes (sometimes up to 5 mins, and in extremelly rare cases up to 10 mins) in PROD.
 
-The lambda generates all files from [today]+2 to [today]+14, and ensures that [today]+2. Moreover we do not generate any file at hour 0 (meaning between midnight and 1am) and we do not generate file index 2, eg: [today]+2, after 10am.
+The lambda generates all files from [today]+2 to [today]+14. This is not done in one excecution but happens over hours (we generate one file per hour). Moreover we do not generate any file at hour 0 (meaning between midnight and 1am) and we do not generate file index 2, eg: [today]+2, after 10am.
 
 It is possible to manually generate a particular file (or a small number of files) in the aws console (see next section).
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,7 @@ export const main = async (indices?: number[]) => {
     console.log('main function has completed');
 };
 
-function indexGenerator(): number | null {
+function getDayOffsetToGenerate(): number | null {
     // This function is not pure, its return value depends on the time of the day.
     // It returns ether a number or null.
     // null signifies that a file should not be generated at this time.
@@ -95,7 +95,7 @@ async function generateOneFileUsingCurrentTimeToDeriveDayIndex(
     // This function generates a file whose index is derived from the current hour of the day
     // It is the function that is naturally triggered when the lambda runs on schedule.
 
-    const dayIndex = indexGenerator();
+    const dayIndex = getDayOffsetToGenerate();
 
     if (dayIndex === null) {
         return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,25 +35,71 @@ export const main = async (indices?: number[]) => {
     console.log('main function has completed');
 };
 
-async function generateOneFileUsingCurrentTimeToDeriveDayIndex(
-    zuoraBearerToken: string,
-) {
-    // Date: 29th October 2023
+function indexGenerator(): number | null {
+    // This function is not pure, its return value depends on the time of the day.
+    // It returns ether a number or null.
+    // null signifies that a file should not be generated at this time.
+    // Otherwise the number id a day index of the file.
 
-    // Here is the current, most recent scheme for file generation. Since we cannot generate all 14 files
-    // sequentially in production, and since running them in parallel is not advised (source: John), we are
-    // simply going to spread the generation over a period of time. In this current version we simply generate the
-    // files over 14 hours
+    // Rules:
+    // - Rule 1: We generate files from index 2 to index 14 (meaning [today]+2 to [today]+14)
+    // - Rule 2: We start generation after 1am to let holiday stops finish.
+    //           In other words, we do not generate during hour 0 of the day
+    // - Rule 3: We only generate index 2 before 10am.
 
-    // dayIndex is derived from the current hour of the day
-    // Time 00:MM -> dayIndex = 1
-    // Time 01:MM -> dayIndex = 2
-    // ...
-    // Time 13:MM -> dayIndex = 14
-    // Time 14:MM -> dayIndex = 1
+    // The mapping is:
+    // Hour 00 -> dayIndex = 1 (index 1 is not generated) Rule 1 and Rule 2
+    // Hour 01 -> dayIndex = 2
+    // Hour 02 -> dayIndex = 3
+    // Hour 03 -> dayIndex = 4
+    // Hour 04 -> dayIndex = 5
+    // Hour 05 -> dayIndex = 6
+    // Hour 06 -> dayIndex = 7
+    // Hour 07 -> dayIndex = 8
+    // Hour 08 -> dayIndex = 9
+    // Hour 09 -> dayIndex = 10
+    // Hour 10 -> dayIndex = 11
+    // Hour 11 -> dayIndex = 12
+    // Hour 12 -> dayIndex = 13
+    // Hour 13 -> dayIndex = 14
+    // Hour 14 -> dayIndex = 1 (index 1 is not generated) Rule 1
+    // Hour 15 -> dayIndex = 2 (index 2 is not generated after 10am) Rule 3
+    // Hour 16 -> dayIndex = 3
+    // Hour 17 -> dayIndex = 4
+    // Hour 18 -> dayIndex = 5
     // etc...
 
     const dayIndex = 1 + (new Date().getUTCHours() % 14);
+
+    // Rule 1
+    if (dayIndex === 1) {
+        return null;
+    }
+
+    // Rule 2
+    if (new Date().getUTCHours() === 0) {
+        return null;
+    }
+
+    // Rule 3
+    if (dayIndex === 2 && new Date().getUTCHours() >= 10) {
+        return null;
+    }
+
+    return dayIndex;
+}
+
+async function generateOneFileUsingCurrentTimeToDeriveDayIndex(
+    zuoraBearerToken: string,
+) {
+    // This function generates a file whose index is derived from the current hour of the day
+    // It is the function that is naturally triggered when the lambda runs on schedule.
+
+    const dayIndex = indexGenerator();
+
+    if (dayIndex === null) {
+        return;
+    }
 
     await generateFileForDay(zuoraBearerToken, dayIndex);
 }


### PR DESCRIPTION
This updates the generation logic, with the following rules:

1. We are now generating [today]+2 to [index]+14. 
2. We avoid generating anything at hour 0 (between midnight and 1am).
3. We do not regenerate [today]+2 after 10am. 
