### PR TITLE
Add Saturday to week day map

### DIFF
--- a/src/libs/zuora.ts
+++ b/src/libs/zuora.ts
@@ -115,7 +115,7 @@ Additional Comms                                                   # reserved fo
             'Wednesday',
             'Thursday',
             'Friday',
-            'Sunday',
+            'Saturday',
         ];
         return days[index];
     };


### PR DESCRIPTION
## What does this change?
Fixes a mistake in `dayMapping` where Sunday was listed twice, with no Saturday.

We noticed that Sixday (Monday - Saturday) National Delivery subscriptions were not being fulfilled. But Weekend and Everyday were ok. We spotted that in `dayMapping`, Sunday was listed at the start and the end. So for a Saturday fulfilment, it would actually get `Sunday` as the day of the week and only pick up subs with Sunday rate plans charges (e.g. Everyday and Weekend).