### PR TITLE
activate bucket versioning

### DIFF
--- a/cdk/lib/__snapshots__/national-delivery-fulfilment.test.ts.snap
+++ b/cdk/lib/__snapshots__/national-delivery-fulfilment.test.ts.snap
@@ -151,6 +151,9 @@ exports[`The NationalDeliveryFulfilment stack matches the snapshot 1`] = `
             "Value": "CODE",
           },
         ],
+        "VersioningConfiguration": {
+          "Status": "Enabled",
+        },
       },
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
@@ -579,6 +582,9 @@ exports[`The NationalDeliveryFulfilment stack matches the snapshot 2`] = `
             "Value": "PROD",
           },
         ],
+        "VersioningConfiguration": {
+          "Status": "Enabled",
+        },
       },
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",

--- a/cdk/lib/national-delivery-fulfilment.ts
+++ b/cdk/lib/national-delivery-fulfilment.ts
@@ -43,6 +43,7 @@ export class NationalDeliveryFulfilment extends GuStack {
 
         const dataBucket = new Bucket(this, 'DataBucket', {
             bucketName: bucketName,
+            versioned: true
         });
 
         nationalDeliveryFulfilmentLambda.addToRolePolicy(


### PR DESCRIPTION
In order to be able to see the intermediary version of fulfilment files (useful during investigations and forensics), we activate versioning on the s3 buckets