### PR TITLE
Query Zuora batch completion every 10 seconds

### DIFF
--- a/src/libs/zuora.ts
+++ b/src/libs/zuora.ts
@@ -303,7 +303,7 @@ async function jobIdToFileId(
         if (receipt.status) {
             return Promise.resolve(receipt); // The receipt is obtained as a ZuoraBatchJobStatusReceipt and returned as as ZuoraDataFileIds
         }
-        await sleep(1 * 1000); // sleeping for 1 seconds
+        await sleep(10 * 1000); // sleeping for 10 seconds
     }
 }
 


### PR DESCRIPTION
This moves the frequency of the Zuora batch completion check from every 1 second to every 10 seconds, to avoid spamming Zuora and polluting the AWS logs.