### PR TITLE
feat: remove axios high vulnerability for native Node fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
         "@types/uuid": "^10.0.0",
         "aws-lambda": "^1.0.7",
         "aws-sdk": "^2.1691.0",
-        "axios": "1.7.7",
         "csv-parse": "^5.5.6",
         "csv-writer": "^1.6.0",
         "moment": "^2.30.1",

--- a/src/libs/identity.ts
+++ b/src/libs/identity.ts
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import { getSsmValue } from '../utils/ssm';
 
 interface IdAPIUserConsent {
@@ -32,14 +31,13 @@ async function queryUserDetailsFromIdAPI(
 
     //console.log(`url: ${url}`);
 
-    const params = {
+    const response = await fetch(url, {
         method: 'GET',
         headers: {
             Authorization: `Bearer ${identityAPIBearerToken}`,
         },
-    };
+    });
 
-    const response = await axios.get(url, params);
     /*
         response.data is a
         {
@@ -68,7 +66,7 @@ async function queryUserDetailsFromIdAPI(
             }
         }
     */
-    return (await response.data) as IdAPIUserConsent;
+    return (await response.json()) as IdAPIUserConsent;
 }
 
 export async function validateIdentityIdForPhoneNumberInclusion(

--- a/src/libs/salesforce.ts
+++ b/src/libs/salesforce.ts
@@ -84,7 +84,7 @@ async function getSalesforceBearerInformation(
     try {
         const response = await fetch(url, {
             method: 'POST',
-            body: JSON.stringify(requestBody),
+            body: new URLSearchParams(requestBody),
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded',
             },

--- a/src/libs/salesforce.ts
+++ b/src/libs/salesforce.ts
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import { getSsmValue } from '../utils/ssm';
 
 export interface SalesforceSSMConfig {
@@ -83,13 +82,14 @@ async function getSalesforceBearerInformation(
     const url = `${saleforceSSMConfig.authenticationBaseUrl}/services/oauth2/token`;
 
     try {
-        const params = {
+        const response = await fetch(url, {
+            method: 'POST',
+            body: JSON.stringify(requestBody),
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded',
             },
-        };
-        const response = await axios.post(url, requestBody, params);
-        return (await response.data) as SalesforceBearerInformation;
+        });
+        return (await response.json()) as SalesforceBearerInformation;
     } catch (error) {
         throw new Error(
             `error while retrieving salesforce bearer token: ${error}`,
@@ -108,13 +108,13 @@ async function runPhoneBookQuery(
         bearerInformation.instance_url
     }/services/data/v46.0/query/?q=${encodeURIComponent(query)}`;
     console.log(url);
-    const params = {
+
+    const response = await fetch(url, {
         method: 'GET',
         headers: {
             Authorization: `Bearer ${bearerInformation.access_token}`,
         },
-    };
-    const response = await axios.get(url, params);
+    });
     /*
         response.data is a
             {
@@ -141,7 +141,7 @@ async function runPhoneBookQuery(
                     }
                 }
             */
-    return (await response.data) as PhoneBookQueryAnswerData;
+    return (await response.json()) as PhoneBookQueryAnswerData;
 }
 
 function phoneBookQueryAnswerDataToPhoneBookRecords(

--- a/src/libs/zuora.ts
+++ b/src/libs/zuora.ts
@@ -54,6 +54,9 @@ async function fetchZuoraBearerToken1(
     const client_id = await getSsmValue(stage, 'zuora-client-id');
     const client_secret = await getSsmValue(stage, 'zuora-client-secret');
 
+    if (!client_id) throw new Error('Zuora client_id not found');
+    if (!client_secret) throw new Error('Zuora client_secret not found');
+
     const data = {
         client_id: client_id,
         client_secret: client_secret,
@@ -62,12 +65,12 @@ async function fetchZuoraBearerToken1(
 
     const response = await fetch(url, {
         method: 'POST',
-        body: JSON.stringify(data),
+        body: new URLSearchParams(data),
         headers: {
             'Content-Type': 'application/x-www-form-urlencoded',
         },
     });
-    console.log(JSON.stringify(response));
+
     return await response.json();
 }
 

--- a/src/libs/zuora.ts
+++ b/src/libs/zuora.ts
@@ -53,6 +53,7 @@ async function fetchZuoraBearerToken1(
     const url = authTokenQueryUrl(stage);
     const client_id = await getSsmValue(stage, 'zuora-client-id');
     const client_secret = await getSsmValue(stage, 'zuora-client-secret');
+
     const data = {
         client_id: client_id,
         client_secret: client_secret,
@@ -66,6 +67,7 @@ async function fetchZuoraBearerToken1(
             'Content-Type': 'application/x-www-form-urlencoded',
         },
     });
+    console.log(JSON.stringify(response));
     return await response.json();
 }
 

--- a/src/libs/zuora.ts
+++ b/src/libs/zuora.ts
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import moment from 'moment';
 import { getSsmValue } from '../utils/ssm';
 import { sleep } from '../utils/sleep';
@@ -59,13 +58,15 @@ async function fetchZuoraBearerToken1(
         client_secret: client_secret,
         grant_type: 'client_credentials',
     };
-    const params = {
+
+    const response = await fetch(url, {
+        method: 'POST',
+        body: JSON.stringify(data),
         headers: {
             'Content-Type': 'application/x-www-form-urlencoded',
         },
-    };
-    const response = await axios.post(url, data, params);
-    return await response.data;
+    });
+    return await response.json();
 }
 
 export async function fetchZuoraBearerToken2(stage: string): Promise<string> {
@@ -205,14 +206,17 @@ async function submitQueryToZuora(
     console.log(`date: ${date}; submitting batch queries to zuora`);
     const url = `${zuoraServerUrl(stage)}/apps/api/batch-query/`;
     const data = zuoraBatchQueries(date, today);
-    const params = {
+
+    const response = await fetch(url, {
+        method: 'POST',
+        body: JSON.stringify(data),
         headers: {
             Authorization: `Bearer ${zuoraBearerToken}`,
             'Content-Type': 'application/json',
         },
-    };
-    const response = await axios.post(url, data, params);
-    return (await response.data) as ZuoraBatchSubmissionReceipt;
+    });
+
+    return (await response.json()) as ZuoraBatchSubmissionReceipt;
 }
 
 async function checkJobStatus(
@@ -223,14 +227,16 @@ async function checkJobStatus(
 ): Promise<ZuoraBatchJobStatusReceipt> {
     console.log(`date: ${date}; check job status: jobId: ${jobId}`);
     const url = `${zuoraServerUrl(stage)}/apps/api/batch-query/jobs/${jobId}`;
-    const params = {
+
+    const response = await fetch(url, {
+        method: 'GET',
         headers: {
             Authorization: `Bearer ${zuoraBearerToken}`,
             'Content-Type': 'application/json',
         },
-    };
-    const response = await axios.get(url, params);
-    const data = await response.data;
+    });
+
+    const data = await response.json();
     console.log(`date: ${date}; checkJobStatus: data: ${JSON.stringify(data)}`);
 
     if (data.status === 'completed') {
@@ -268,15 +274,14 @@ async function readDataFileFromZuora(
     fileId: string,
 ): Promise<string> {
     const url = `${zuoraServerUrl(stage)}/apps/api/batch-query/file/${fileId}`;
-    const params = {
+    const response = await fetch(url, {
         method: 'GET',
         headers: {
             Authorization: `Bearer ${zuoraBearerToken}`,
             'Content-Type': 'application/json',
         },
-    };
-    const response = await axios.get(url, params);
-    return await response.data;
+    });
+    return await response.json();
 }
 
 async function jobIdToFileId(

--- a/src/libs/zuora.ts
+++ b/src/libs/zuora.ts
@@ -281,7 +281,7 @@ async function readDataFileFromZuora(
             'Content-Type': 'application/json',
         },
     });
-    return await response.json();
+    return await response.text();
 }
 
 async function jobIdToFileId(

--- a/yarn.lock
+++ b/yarn.lock
@@ -3473,11 +3473,6 @@ async@^3.2.3:
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.5.tgz#ebd52a8fdaf7a2289a24df399f8d8485c8a46b66"
   integrity sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==
 
-asynckit@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
-  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
-
 available-typed-arrays@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
@@ -3515,15 +3510,6 @@ aws-sdk@^2.1691.0, aws-sdk@^2.814.0:
     util "^0.12.4"
     uuid "8.0.0"
     xml2js "0.6.2"
-
-axios@1.7.7:
-  version "1.7.7"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.7.tgz#2f554296f9892a72ac8d8e4c5b79c14a91d0a47f"
-  integrity sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==
-  dependencies:
-    follow-redirects "^1.15.6"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
 
 babel-jest@^29.7.0:
   version "29.7.0"
@@ -3847,13 +3833,6 @@ colorette@^2.0.20:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
 
-combined-stream@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
-  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
-  dependencies:
-    delayed-stream "~1.0.0"
-
 commander@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/commander/-/commander-3.0.2.tgz#6837c3fb677ad9933d1cfba42dd14d5117d6b39e"
@@ -4049,11 +4028,6 @@ define-properties@^1.1.3, define-properties@^1.1.4, define-properties@^1.2.0, de
     define-data-property "^1.0.1"
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
-
-delayed-stream@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
-  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -4782,26 +4756,12 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
 
-follow-redirects@^1.15.6:
-  version "1.15.6"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
-  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
-
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
   integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
   dependencies:
     is-callable "^1.1.3"
-
-form-data@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
-  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    mime-types "^2.1.12"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -6125,18 +6085,6 @@ micromatch@^4.0.4, micromatch@~4.0.8:
     braces "^3.0.3"
     picomatch "^2.3.1"
 
-mime-db@1.52.0:
-  version "1.52.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
-  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
-
-mime-types@^2.1.12:
-  version "2.1.35"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
-  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
-  dependencies:
-    mime-db "1.52.0"
-
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -6504,11 +6452,6 @@ prompts@^2.0.1:
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
-
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 punycode@1.3.2:
   version "1.3.2"


### PR DESCRIPTION
## What does this change?

This replaces `axios` with native Node fetch, to remove [these high vulnerabilities](https://app.snyk.io/org/the-guardian-cuu/project/f968c236-9c18-410f-aa73-92e0879f306a).

<img width="1387" alt="Screenshot 2024-10-03 at 16 37 00" src="https://github.com/user-attachments/assets/1deca1a4-e712-4c88-ba0e-f77b7a5f2df6">

## How to test

- Locally
  - Fetch Zuora CODE bearer token and use it in the `local.ts` file
  - Run `npx ts-node src/local.ts`

  <img width="656" alt="Screenshot 2024-10-07 at 11 33 46" src="https://github.com/user-attachments/assets/83a8da8f-57f9-42f4-a501-62e9c373d220">

- CODE from the AWS console
  - Test [this](https://eu-west-1.console.aws.amazon.com/lambda/home?region=eu-west-1#/functions/membership-national-delivery-fulfilment-CODE?tab=testing) CODE lambda

  <img width="1201" alt="Screenshot 2024-10-07 at 12 13 39" src="https://github.com/user-attachments/assets/d73ddbd4-0196-46d6-b7fe-d4b4cc40a5e3">
