### PR TITLE
reduce the scope of the new alarm

### DIFF
--- a/cdk/lib/__snapshots__/national-delivery-fulfilment.test.ts.snap
+++ b/cdk/lib/__snapshots__/national-delivery-fulfilment.test.ts.snap
@@ -161,7 +161,7 @@ exports[`The NationalDeliveryFulfilment stack matches the snapshot 1`] = `
     },
     "ErrorExecutionAlarm9DD60FED": {
       "Properties": {
-        "ActionsEnabled": true,
+        "ActionsEnabled": false,
         "AlarmActions": [
           {
             "Fn::Join": [
@@ -183,6 +183,12 @@ exports[`The NationalDeliveryFulfilment stack matches the snapshot 1`] = `
         "AlarmDescription": "national-delivery-fulfilment: error while executing lambda",
         "AlarmName": "national-delivery-fulfilment: error",
         "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": "membership-national-delivery-fulfilment-CODE",
+          },
+        ],
         "EvaluationPeriods": 1,
         "MetricName": "Errors",
         "Namespace": "AWS/Lambda",
@@ -648,6 +654,12 @@ exports[`The NationalDeliveryFulfilment stack matches the snapshot 2`] = `
         "AlarmDescription": "national-delivery-fulfilment: error while executing lambda",
         "AlarmName": "national-delivery-fulfilment: error",
         "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": "membership-national-delivery-fulfilment-PROD",
+          },
+        ],
         "EvaluationPeriods": 1,
         "MetricName": "Errors",
         "Namespace": "AWS/Lambda",

--- a/cdk/lib/national-delivery-fulfilment.ts
+++ b/cdk/lib/national-delivery-fulfilment.ts
@@ -125,8 +125,6 @@ export class NationalDeliveryFulfilment extends GuStack {
                 }
             )
         );
-
-        const snsTopicName = `alarms-handler-topic-${this.stage}`;
     
         const errorMetric = new Metric({
             namespace: 'AWS/Lambda',
@@ -137,6 +135,7 @@ export class NationalDeliveryFulfilment extends GuStack {
             }
         });
 
+        const snsTopicName = `alarms-handler-topic-${this.stage}`;
         const isProd = this.stage === 'PROD';
 
         new GuAlarm(this, 'ErrorExecutionAlarm', {

--- a/cdk/lib/national-delivery-fulfilment.ts
+++ b/cdk/lib/national-delivery-fulfilment.ts
@@ -132,7 +132,12 @@ export class NationalDeliveryFulfilment extends GuStack {
             namespace: 'AWS/Lambda',
             metricName: 'Errors',
             statistic: 'Sum',
+            dimensionsMap: {
+                FunctionName: `membership-national-delivery-fulfilment-${this.stage}`,
+            }
         });
+
+        const isProd = this.stage === 'PROD';
 
         new GuAlarm(this, 'ErrorExecutionAlarm', {
             app,
@@ -143,6 +148,7 @@ export class NationalDeliveryFulfilment extends GuStack {
             comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
             threshold: 0,
             evaluationPeriods: 1,
+            actionsEnabled: isProd,
         });
 
     }


### PR DESCRIPTION
This is a follow up of the PR we did earlier today ( https://github.com/guardian/national-delivery-fulfilment/pull/69 ), to reduce the scope of the alarm to the function itself.