### PR TITLE
Prevent duplicate fulfilments caused by overlapping "UpdateProduct" amendments

### DIFF
--- a/src/libs/zuora.ts
+++ b/src/libs/zuora.ts
@@ -161,7 +161,13 @@ function zuoraBatchQueries(date: string, today: string) {
           RatePlanCharge.EffectiveEndDate >= '${today}' AND
           Subscription.Status = 'Active' AND
           Subscription.AutoRenew = true AND
-          (RatePlan.AmendmentType IS NULL OR RatePlan.AmendmentType != 'RemoveProduct')
+          ( 
+            RatePlan.AmendmentType IS NULL OR 
+            ( 
+                RatePlan.AmendmentType != 'RemoveProduct' AND 
+                RatePlan.AmendmentType != 'UpdateProduct' 
+            ) 
+          )
         )
       )
   `;


### PR DESCRIPTION
## Background
Recently we completed a large number of update amendments to subscriptions after an issue with calculating a print price rise. 

This updated a single charge in the existing rate plan to correct a pricing discrepancy. 

Recently, our fulfilment partners have notified us that there have been duplicates in some fulfilment files. This was observed in two Monday files and two Saturday files - all since the price rise discrepancy updates were completed. 

### Customer Impact
Each customer impacted was sent TWO newspapers. Around 80 customers have been impacted by the time we worked out what the problem was.

## What does this change?

We found that this was due to the way Zuora applies end dates to update amendments on subscriptions. The effective end date of the previous charge version is the same as the effective start date of the next version. 

<img width="405" height="72" alt="Screenshot 2025-09-29 at 14 30 47" src="https://github.com/user-attachments/assets/cba606a3-997c-4d61-8a91-9283b6696e57" />

On this "crossover date", our fulfilment lambda was retrieving BOTH the old and new versions of the rate plan charge - putting both in the fulfilment file.

In this PR we update the query so that `UpdateProduct` amendments are considered in the same way as `RemoveProduct` amendments - preventing any overlap between each version.

## How to test

The query can be replicated in the datalake. The old version is like:

```
SELECT
      RateplanCharge.quantity,
      Subscription.Name,
      Subscription.Status,
      ProductRatePlanCharge.product_type_c,
      Product.Name,
      RatePlanCharge.effective_start_date,
      RatePlanCharge.effective_end_date,
      RatePlan.amendment_type

    FROM
       datatech-fivetran.zuora.rate_plan_charge rateplancharge
        LEFT JOIN datatech-fivetran.zuora.subscription Subscription ON rateplancharge.subscription_id = Subscription.id
        LEFT JOIN datatech-fivetran.zuora.rate_plan RatePlan ON RatePlan.id = rateplancharge.rate_plan_id
        LEFT JOIN datatech-fivetran.zuora.product_rate_plan ProductRatePlan ON ProductRatePlan.id = RatePlan.product_rate_plan_id
        LEFT JOIN datatech-fivetran.zuora.product_rate_plan_charge ProductRatePlanCharge ON ProductRatePlanCharge.id = rateplancharge.product_rate_plan_charge_id
        LEFT JOIN datatech-fivetran.zuora.product Product ON Product.id = rateplancharge.product_id
    WHERE
      Subscription.Name = '<ENTER-SUB-NUMBER>' AND
     (Subscription.Status = 'Active' OR Subscription.Status = 'Cancelled') AND
     ProductRatePlanCharge.product_type_c = 'Print Monday' AND
     Product.Name = 'Newspaper Delivery' AND
     RatePlanCharge.effective_start_date <= '2025-09-29' AND
     (
      RatePlanCharge.effective_end_date > '2025-09-29' OR
      ( 
        RatePlanCharge.effective_end_date >= '2025-09-29' AND
        Subscription.Status = 'Active' AND Subscription.auto_renew = true AND 
        ( RatePlan.amendment_type IS NULL OR ( RatePlan.amendment_type != 'RemoveProduct' AND RatePlan.amendment_type != 'UpdateProduct' ) )
      )
     ) 
     AND
     (RatePlanCharge.MRR != 0 OR ProductRatePlan.frontend_id_c != 'EchoLegacy')
```

Compare with the updated version that equates `UpdateProduct` with `RemoveProduct`:

```
SELECT
      RateplanCharge.quantity,
      Subscription.Name,
      Subscription.Status,
      ProductRatePlanCharge.product_type_c,
      Product.Name,
      RatePlanCharge.effective_start_date,
      RatePlanCharge.effective_end_date,
      RatePlan.amendment_type

    FROM
       datatech-fivetran.zuora.rate_plan_charge rateplancharge
        LEFT JOIN datatech-fivetran.zuora.subscription Subscription ON rateplancharge.subscription_id = Subscription.id
        LEFT JOIN datatech-fivetran.zuora.rate_plan RatePlan ON RatePlan.id = rateplancharge.rate_plan_id
        LEFT JOIN datatech-fivetran.zuora.product_rate_plan ProductRatePlan ON ProductRatePlan.id = RatePlan.product_rate_plan_id
        LEFT JOIN datatech-fivetran.zuora.product_rate_plan_charge ProductRatePlanCharge ON ProductRatePlanCharge.id = rateplancharge.product_rate_plan_charge_id
        LEFT JOIN datatech-fivetran.zuora.product Product ON Product.id = rateplancharge.product_id
    WHERE
      Subscription.Name = '<ENTER-SUB-NUMBER>' AND
     (Subscription.Status = 'Active' OR Subscription.Status = 'Cancelled') AND
     ProductRatePlanCharge.product_type_c = 'Print Monday' AND
     Product.Name = 'Newspaper Delivery' AND
     RatePlanCharge.effective_start_date <= '2025-09-29' AND
     (
      RatePlanCharge.effective_end_date > '2025-09-29' OR
      ( 
        RatePlanCharge.effective_end_date >= '2025-09-29' AND
        Subscription.Status = 'Active' AND Subscription.auto_renew = true AND 
        ( RatePlan.amendment_type IS NULL OR RatePlan.amendment_type NOT IN ('RemoveProduct', 'UpdateProduct') )
      )
     ) 
     AND
     (RatePlanCharge.MRR != 0 OR ProductRatePlan.frontend_id_c != 'EchoLegacy')
```

To test in CODE, deploy the correct version and run the step function to verify that everything runs as expected:

<img width="743" height="403" alt="Screenshot 2025-09-29 at 15 56 52" src="https://github.com/user-attachments/assets/dd396b42-17b3-4c37-b8c9-24d0dff89b40" />



## How can we measure success?
We can be more confident that each relevant rate plan charge for a subscription is being picked up once.

## Have we considered potential risks?
Fulfilment is obviously an extremely critical process that we need to be cautious with. 

We can test this in production after deployment by generating the file for Monday 29 September immediately - this has already been retrieved by our fulfilment partners, and we can use this to inspect the results and verify that a) the duplicates have been removed and b) no other subscriptions are missing.