### PR TITLE
Remove aws-actions/configure-aws-credentials usage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,11 +30,6 @@ jobs:
           yarn test
           yarn synth
         working-directory: cdk
-      - name: AWS Auth
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          aws-region: eu-west-1
       - name: Upload to riff-raff
         uses: guardian/actions-riff-raff@v4.3.0
         with:


### PR DESCRIPTION
Removes workflow steps using aws-actions/configure-aws-credentials.

v4 and above of riff raff upload action handles the required credentials internally.  These credentials fetches are no longer required.  For security purposes, we would prefer not to have unused credentials anywhere. 